### PR TITLE
Do not use Git version to identify builds

### DIFF
--- a/python/src/cradle/command.py
+++ b/python/src/cradle/command.py
@@ -287,21 +287,6 @@ class IntrospectionClearAdminCommand(Command):
         return None
 
 
-class QueryRequestsMetaInfoCommand(Command):
-    def name(self) -> str:
-        return 'query requests meta info'
-
-    def create_content(self) -> Content:
-        return \
-            {
-                'requests_meta_info_query': {
-                }
-            }
-
-    def decode_content(self, content: Content) -> Object:
-        return content['requests_meta_info_response']
-
-
 class ResolveRequestCommand(Command):
     def __init__(self, context_id: str, req_data: Object, remote: bool):
         super().__init__(context_id)

--- a/python/src/cradle/session.py
+++ b/python/src/cradle/session.py
@@ -12,18 +12,11 @@ class Session:
     def __init__(self):
         self.impl = conn.Connection()
         self.context_id = self.impl.context_id
-        self._git_version = None
         self.registration()
 
     @property
     def api_url(self) -> str:
         return self.impl.api_url
-
-    @property
-    def git_version(self) -> str:
-        if self._git_version is None:
-            self._git_version = self.query_requests_meta_info()['git_version']
-        return self._git_version
 
     def registration(self) -> None:
         command = cmd.RegistrationCommand(self.context_id,
@@ -120,12 +113,6 @@ class Session:
         """Receive a response for a started request (whatever its type)."""
         print('RECEIVE RESPONSE', file=sys.stderr)
         return self.impl.receive_response(command)
-
-    def query_requests_meta_info(self) -> cmd.Object:
-        '''Retrieve info on the requests subsystem'''
-        print('QUERY REQUESTS META INFO', file=sys.stderr)
-        command = cmd.QueryRequestsMetaInfoCommand(self.context_id)
-        return self.impl.perform_command(command)
 
     def resolve_request(self, req_data: cmd.Object, remote: bool) -> cmd.Object:
         print(f'RESOLVE REQUEST {remote=}', file=sys.stderr)

--- a/python/tests/integration/make_request.py
+++ b/python/tests/integration/make_request.py
@@ -11,8 +11,6 @@ from cradle.session import Session
 def make_req(session: Session, uuid_base: str, title: str, args: List) -> Any:
     # Request metadata
     uuid = uuid_base
-    # Or, if using Git version:
-    # uuid = f'{uuid_base}+{session.git_version}'
 
     # Args
     args_data = {f'tuple_element{i}': arg for i, arg in enumerate(args)}

--- a/src/cradle/inner/requests/uuid.cpp
+++ b/src/cradle/inner/requests/uuid.cpp
@@ -32,14 +32,6 @@ request_uuid::set_level(caching_level_type level)
     return *this;
 }
 
-request_uuid&
-request_uuid::use_git_version()
-{
-    check_not_finalized();
-    use_git_version_ = true;
-    return *this;
-}
-
 void
 request_uuid::check_not_finalized() const
 {
@@ -57,29 +49,7 @@ request_uuid::do_finalize() const
         static const char* const level_exts[] = {"+none", "+mem", "+full"};
         str_ += level_exts[static_cast<int>(level_)];
     }
-    if (use_git_version_)
-    {
-        str_ += '+';
-        str_ += get_git_version();
-    }
     finalized_ = true;
-}
-
-std::string const&
-request_uuid::get_git_version()
-{
-    if (git_version_.empty())
-    {
-        git_version_ = ::version_info.commit_object_name;
-        if (::version_info.dirty)
-        {
-            // If there are local modifications, it becomes the user's
-            // responsibility to manually remove outdated files like the
-            // disk cache.
-            git_version_ += "-dirty";
-        }
-    }
-    return git_version_;
 }
 
 } // namespace cradle

--- a/src/cradle/inner/requests/uuid.h
+++ b/src/cradle/inner/requests/uuid.h
@@ -66,12 +66,6 @@ class request_uuid
     request_uuid&
     set_level(caching_level_type level);
 
-    // Causes the base uuid to be combined with Git information to produce
-    // something unique across application runs on different builds.
-    // It is unclear how useful this is.
-    request_uuid&
-    use_git_version();
-
     // Returns the full uuid (base + any extensions)
     std::string const&
     str() const
@@ -91,9 +85,6 @@ class request_uuid
     {
         return str() <=> other.str();
     }
-
-    static std::string const&
-    get_git_version();
 
     // Serialize using cereal.
     // This results in JSON
@@ -122,8 +113,6 @@ class request_uuid
     // Used in load_with_name() only
     request_uuid() = default;
 
-    inline static std::string git_version_;
-
     // str_ is the full string if finalized_, base until then
     mutable std::string str_;
     mutable bool finalized_{false};
@@ -131,7 +120,6 @@ class request_uuid
     // Modifiers
     bool include_level_{false};
     caching_level_type level_{};
-    bool use_git_version_{false};
 
     void
     check_not_finalized() const;

--- a/src/cradle/rpclib/client/proxy_impl.cpp
+++ b/src/cradle/rpclib/client/proxy_impl.cpp
@@ -177,11 +177,11 @@ bool
 rpclib_client_impl::server_is_running()
 {
     logger_->info("test whether rpclib server is running");
-    std::string server_git_version;
+    std::string server_rpclib_protocol;
     try
     {
         rpc_client_ = std::make_unique<rpc::client>(localhost_, port_);
-        server_git_version = ping();
+        server_rpclib_protocol = ping();
     }
     catch (rpc::system_error& e)
     {
@@ -191,25 +191,25 @@ rpclib_client_impl::server_is_running()
         return false;
     }
     logger_->info(
-        "received pong {}: rpclib server is running", server_git_version);
-    // Detect a rogue rpclib server instance (TODO finetune)
-    verify_git_version(server_git_version);
+        "received pong {}: rpclib server is running", server_rpclib_protocol);
+    // Detect an incompatible rpclib server instance.
+    verify_rpclib_protocol(server_rpclib_protocol);
     // rpc_client_->set_timeout(30);
     return true;
 }
 
 void
-rpclib_client_impl::verify_git_version(std::string const& server_git_version)
+rpclib_client_impl::verify_rpclib_protocol(
+    std::string const& server_rpclib_protocol)
 {
-    std::string client_git_version{request_uuid::get_git_version()};
-    if (server_git_version != client_git_version)
+    if (server_rpclib_protocol != RPCLIB_PROTOCOL)
     {
         auto msg{fmt::format(
             "rpclib server has {}, client has {}",
-            server_git_version,
-            client_git_version)};
+            server_rpclib_protocol,
+            RPCLIB_PROTOCOL)};
         logger_->error(msg);
-        throw remote_error("code version mismatch", msg);
+        throw remote_error("rpclib protocol mismatch", msg);
     }
 }
 

--- a/src/cradle/rpclib/client/proxy_impl.h
+++ b/src/cradle/rpclib/client/proxy_impl.h
@@ -67,7 +67,7 @@ class rpclib_client_impl
     ack_response(uint32_t pool_id);
 
     void
-    verify_git_version(std::string const& server_git_version);
+    verify_rpclib_protocol(std::string const& server_rpclib_protocol);
 
  private:
     inline static std::shared_ptr<spdlog::logger> logger_;

--- a/src/cradle/rpclib/common/common.h
+++ b/src/cradle/rpclib/common/common.h
@@ -1,12 +1,21 @@
 #ifndef CRADLE_RPCLIB_COMMON_COMMON_H
 #define CRADLE_RPCLIB_COMMON_COMMON_H
 
+#include <string>
+#include <tuple>
+
 namespace cradle {
 
 using rpclib_port_t = uint16_t;
 
 static const inline rpclib_port_t RPCLIB_PORT_PRODUCTION = 8098;
 static const inline rpclib_port_t RPCLIB_PORT_TESTING = 8096;
+
+// Protocol defining the rpclib messages.
+// Must be identical between client and server (currently always running on
+// the same machine).
+// Must be increased when the protocol changes.
+static const inline std::string RPCLIB_PROTOCOL{"1"};
 
 // Configuration keys for rpclib
 struct rpclib_config_keys

--- a/src/cradle/rpclib/server/main.cpp
+++ b/src/cradle/rpclib/server/main.cpp
@@ -168,7 +168,7 @@ run_server(cli_options const& options)
     srv.bind("ack_response", [&](int response_id) {
         return handle_ack_response(hctx, response_id);
     });
-    srv.bind("ping", []() { return request_uuid::get_git_version(); });
+    srv.bind("ping", []() { return RPCLIB_PROTOCOL; });
 
     srv.bind(
         "submit_async", [&](std::string config_json, std::string seri_req) {

--- a/src/cradle/websocket/messages.hpp
+++ b/src/cradle/websocket/messages.hpp
@@ -298,7 +298,6 @@ union client_message_content
     cradle::results_api_query local_results_api_query;
     cradle::introspection_control_request introspection_control;
     cradle::introspection_status_request introspection_status_query;
-    cradle::nil_t requests_meta_info_query;
     cradle::resolve_request_request resolve_request;
 };
 
@@ -351,14 +350,6 @@ struct introspection_status_response
     std::vector<tasklet_overview> tasklets;
 };
 
-// Information on the requests subsystem
-api(struct)
-struct requests_meta_info_response
-{
-    // The Git version string forming part of some request uuid's
-    std::string git_version;
-};
-
 api(union)
 union server_message_content
 {
@@ -384,7 +375,6 @@ union server_message_content
     cradle::local_results_api_response local_results_api_response;
     nil_t introspection_control_response;
     cradle::introspection_status_response introspection_status_response;
-    cradle::requests_meta_info_response requests_meta_info_response;
     cradle::dynamic resolve_request_response;
 };
 

--- a/src/cradle/websocket/server.cpp
+++ b/src/cradle/websocket/server.cpp
@@ -1758,16 +1758,6 @@ process_message(websocket_server_impl& server, client_request request)
                     response));
             break;
         }
-        case client_message_content_tag::REQUESTS_META_INFO_QUERY: {
-            std::string git_version = request_uuid::get_git_version();
-            auto response = make_requests_meta_info_response(git_version);
-            send_response(
-                server,
-                request,
-                make_server_message_content_with_requests_meta_info_response(
-                    response));
-            break;
-        }
         case client_message_content_tag::RESOLVE_REQUEST: {
             auto const& rr = as_resolve_request(content);
             server.logger->info("resolve {}", rr.remote ? "remote" : "local");

--- a/tests/inner/requests/uuid.cpp
+++ b/tests/inner/requests/uuid.cpp
@@ -18,13 +18,6 @@ TEST_CASE("uuid_error ctor - C-style")
     REQUIRE(strlen(res.what()) > 0);
 }
 
-TEST_CASE("request_uuid ctor - Git version", "[uuid]")
-{
-    request_uuid res{"base"};
-    res.use_git_version();
-    REQUIRE(res.str().starts_with("base+"));
-}
-
 TEST_CASE("request_uuid ctor - bad base", "[uuid]")
 {
     REQUIRE_THROWS_WITH(

--- a/tests/rpclib/proxy_impl.cpp
+++ b/tests/rpclib/proxy_impl.cpp
@@ -9,7 +9,7 @@
 
 using namespace cradle;
 
-TEST_CASE("git version mismatch", "[rpclib]")
+TEST_CASE("rpclib protocol mismatch", "[rpclib]")
 {
     inner_resources resources;
     init_test_inner_service(resources);
@@ -17,5 +17,6 @@ TEST_CASE("git version mismatch", "[rpclib]")
         = register_rpclib_client(make_inner_tests_config(), resources);
     auto& impl{client.pimpl()};
 
-    REQUIRE_THROWS_AS(impl.verify_git_version("bad version"), remote_error);
+    REQUIRE_THROWS_AS(
+        impl.verify_rpclib_protocol("incompatible"), remote_error);
 }


### PR DESCRIPTION
Having compatibility checks between client and server is useful, but the Git version is too strict for this purpose.