### PR TITLE
Rpclib busy

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -23,7 +23,7 @@ jobs:
 
     - uses: friendlyanon/setup-vcpkg@v1
       with:
-        committish: 662dbb50e63af15baa2909b7eac5b1b87e86a0aa
+        committish: 0c20b2a97c390e106150837042d921b0939e7ecb
 
     - name: Install
       run: |

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -23,7 +23,7 @@ jobs:
 
     - uses: friendlyanon/setup-vcpkg@v1
       with:
-        committish: 662dbb50e63af15baa2909b7eac5b1b87e86a0aa
+        committish: 0c20b2a97c390e106150837042d921b0939e7ecb
 
     - name: Install
       run: |

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -20,7 +20,7 @@ jobs:
     # TODO: The preprocessing job shouldn't require vcpkg.
     - uses: friendlyanon/setup-vcpkg@v1
       with:
-        committish: 662dbb50e63af15baa2909b7eac5b1b87e86a0aa
+        committish: 0c20b2a97c390e106150837042d921b0939e7ecb
 
     - name: Install
       run: |
@@ -71,7 +71,7 @@ jobs:
 
     - uses: friendlyanon/setup-vcpkg@v1
       with:
-        committish: 662dbb50e63af15baa2909b7eac5b1b87e86a0aa
+        committish: 0c20b2a97c390e106150837042d921b0939e7ecb
 
     - name: Download preprocessed headers
       uses: actions/download-artifact@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,9 +179,16 @@ find_package(spdlog CONFIG REQUIRED)
 find_package(simdjson CONFIG REQUIRED)
 find_package(lz4 CONFIG REQUIRED)
 find_package(cereal CONFIG REQUIRED)
-find_package(rpclib CONFIG REQUIRED)
 find_package(tomlplusplus CONFIG REQUIRED)
 find_path(BSHOSHANY_THREAD_POOL_INCLUDE_DIRS "BS_thread_pool.hpp")
+
+# The patch command may not be idempotent; if anything changes (like GIT_TAG),
+# all build-directory/_deps/fetched_rpclib* should be removed before rebuilding.
+FetchContent_Declare(fetched_rpclib
+    GIT_REPOSITORY https://github.com/rpclib/rpclib.git
+    GIT_TAG "v2.3.0"
+    PATCH_COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/patches/rpclib.patch)
+FetchContent_MakeAvailable(fetched_rpclib)
 
 # TODO: Isolate these so they're only required for testing.
 find_package(Catch2 CONFIG REQUIRED)
@@ -492,7 +499,7 @@ target_link_libraries(cradle_rpclib_client PUBLIC
     cradle_inner
     Boost::headers
     cppcoro
-    rpclib::rpc
+    rpc
     spdlog::spdlog)
 
 # The typing library (a.o.) adds a type system (e.g. dynamics)
@@ -597,7 +604,7 @@ target_link_libraries(rpclib_server PRIVATE
     Boost::program_options
     cppcoro
     fmt::fmt
-    rpclib::rpc
+    rpc
     spdlog::spdlog)
 
 # Convenience target denoting all servers

--- a/patches/rpclib.patch
+++ b/patches/rpclib.patch
@@ -1,0 +1,36 @@
+diff --git a/include/rpc/msgpack/v1/object.hpp b/include/rpc/msgpack/v1/object.hpp
+index a7220a5..077664f 100644
+--- a/include/rpc/msgpack/v1/object.hpp
++++ b/include/rpc/msgpack/v1/object.hpp
+@@ -653,7 +653,7 @@ inline object::object(const msgpack_object& o)
+ inline void operator<< (clmdep_msgpack::object& o, const msgpack_object& v)
+ {
+     // FIXME beter way?
+-    std::memcpy(&o, &v, sizeof(v));
++    std::memcpy(static_cast<void*>(&o), &v, sizeof(v));
+ }
+ 
+ inline object::operator msgpack_object() const
+diff --git a/lib/rpc/detail/response.cc b/lib/rpc/detail/response.cc
+index 6169c58..0c461f2 100644
+--- a/lib/rpc/detail/response.cc
++++ b/lib/rpc/detail/response.cc
+@@ -51,14 +51,16 @@ void response::capture_result(RPCLIB_MSGPACK::object_handle &r) {
+     if (!result_) {
+         result_ = std::make_shared<RPCLIB_MSGPACK::object_handle>();
+     }
+-    result_->set(std::move(r).get());
++    result_->set(std::move(r.get()));
++    result_->zone() = std::move(r.zone());
+ }
+ 
+ void response::capture_error(RPCLIB_MSGPACK::object_handle &e) {
+     if (!error_) {
+         error_ = std::shared_ptr<RPCLIB_MSGPACK::object_handle>();
+     }
+-    error_->set(std::move(e).get());
++    error_->set(std::move(e.get()));
++    error_->zone() = std::move(e.zone());
+ }
+ 
+ } /* detail */

--- a/src/cradle/inner/requests/generic.h
+++ b/src/cradle/inner/requests/generic.h
@@ -342,6 +342,11 @@ class local_async_context_intf : public local_context_intf,
     //
     // Note that after this call, tasks can still finish successfully or fail.
     // Thus, a "cancelling" state would not be meaningful.
+    //
+    // Also note that cancellation depends on cooperation by the request
+    // implementation. In particular, an implementation that has no access to
+    // the context object (such as a non-coroutine function_request) is unable
+    // to cooperate. Thus, a cancellation request just may have no effect.
     virtual void
     request_cancellation()
         = 0;

--- a/src/cradle/plugins/domain/testing/requests.cpp
+++ b/src/cradle/plugins/domain/testing/requests.cpp
@@ -56,4 +56,24 @@ cancellable_coro(context_intf& ctx, int loops, int delay)
     co_return res;
 }
 
+int
+non_cancellable_func(int loops, int delay)
+{
+    auto logger = spdlog::get("cradle");
+    logger->info("non_cancellable_func(loops={}, delay={})", loops, delay);
+    int i = 0;
+    for (; i < std::abs(loops); ++i)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+    }
+    if (loops < 0)
+    {
+        logger->info("non_cancellable_func(): throwing error");
+        throw async_error{"non_cancellable_func() failed"};
+    }
+    int res = i + delay;
+    logger->info("non_cancellable_func(): return {}", res);
+    return res;
+}
+
 } // namespace cradle

--- a/src/cradle/plugins/domain/testing/requests.h
+++ b/src/cradle/plugins/domain/testing/requests.h
@@ -56,6 +56,28 @@ rq_cancellable_coro(Loops loops, Delay delay)
         normalize_arg<int, props_type>(std::move(delay)));
 }
 
+// A non-coroutine, non-cancellable, simplified version of cancellable_coro()
+int
+non_cancellable_func(int loops, int delay);
+
+template<caching_level_type Level, typename Loops, typename Delay>
+    requires TypedArg<Loops, int> && TypedArg<Delay, int>
+auto
+rq_non_cancellable_func(Loops loops, Delay delay)
+{
+    constexpr bool introspective{true};
+    using props_type
+        = request_props<Level, request_function_t::plain, introspective>;
+    request_uuid uuid{"non_cancellable_func"};
+    uuid.set_level(Level);
+    std::string title{"non_cancellable_func"};
+    return rq_function(
+        props_type(std::move(uuid), std::move(title)),
+        non_cancellable_func,
+        normalize_arg<int, props_type>(std::move(loops)),
+        normalize_arg<int, props_type>(std::move(delay)));
+}
+
 } // namespace cradle
 
 #endif

--- a/src/cradle/plugins/domain/testing/testing_seri_catalog.cpp
+++ b/src/cradle/plugins/domain/testing/testing_seri_catalog.cpp
@@ -15,6 +15,7 @@ testing_seri_catalog::testing_seri_catalog(
     register_resolver(rq_make_some_blob<caching_level_type::memory>(1, false));
     register_resolver(rq_make_some_blob<caching_level_type::full>(1, false));
     register_resolver(rq_cancellable_coro<caching_level_type::memory>(0, 0));
+    register_resolver(rq_non_cancellable_func<caching_level_type::none>(0, 0));
 }
 
 } // namespace cradle

--- a/src/cradle/rpclib/server/main.cpp
+++ b/src/cradle/rpclib/server/main.cpp
@@ -1,3 +1,4 @@
+#include <cassert>
 #include <chrono>
 #include <cstdlib>
 #include <iostream>
@@ -209,15 +210,10 @@ run_server(cli_options const& options)
         handle_unload_shared_library(hctx, std::move(dll_name));
     });
 
-    // If all handler threads are busy resolving a resolve_sync request,
-    // the server is unresponsive until the first thread finishes.
-    auto num_threads{config.get_number_or_default(
-        rpclib_config_keys::REQUEST_CONCURRENCY, 16)};
-    if (num_threads > 1)
-    {
-        // Create a number of handler threads
-        srv.async_run(num_threads - 1);
-    }
+    auto num_threads{hctx.handler_pool_size()};
+    assert(num_threads >= 2);
+    // Create a pool with all handler threads except one
+    srv.async_run(num_threads - 1);
     // One additional handler on the current thread
     srv.run();
 

--- a/tests/benchmarks/hashing.cpp
+++ b/tests/benchmarks/hashing.cpp
@@ -1,0 +1,62 @@
+#include <string>
+
+#include <benchmark/benchmark.h>
+#include <cppcoro/sync_wait.hpp>
+
+#include <cradle/inner/core/hash.h>
+#include <cradle/inner/core/unique_hash.h>
+#include <cradle/plugins/domain/testing/requests.h>
+
+#include "../support/common.h"
+#include "../support/inner_service.h"
+
+using namespace cradle;
+
+auto
+make_my_blob()
+{
+    std::size_t const size{1000};
+    std::string proxy_name{};
+    auto resources{
+        make_inner_test_resources(proxy_name, testing_domain_option())};
+    testing_request_context ctx{*resources, nullptr, proxy_name};
+    return cppcoro::sync_wait(make_some_blob(ctx, size, false));
+}
+
+void
+BM_BoostHash(benchmark::State& state)
+{
+    auto the_blob = make_my_blob();
+    for (auto _ : state)
+    {
+        benchmark::DoNotOptimize(invoke_hash(the_blob));
+    }
+}
+
+// Finding an existing blob in the memory cache means calculating a Boost
+// hash over the blob, plus comparing the (identical) blobs for equality.
+void
+BM_CompareEqualBlobs(benchmark::State& state)
+{
+    auto blob_a = make_my_blob();
+    auto blob_b = make_my_blob();
+    for (auto _ : state)
+    {
+        benchmark::DoNotOptimize(blob_a == blob_b);
+    }
+}
+
+void
+BM_UniqueHash(benchmark::State& state)
+{
+    auto the_blob = make_my_blob();
+    unique_hasher the_hasher;
+    for (auto _ : state)
+    {
+        update_unique_hash(the_hasher, the_blob);
+    }
+}
+
+BENCHMARK(BM_BoostHash);
+BENCHMARK(BM_CompareEqualBlobs);
+BENCHMARK(BM_UniqueHash);

--- a/tests/inner/resolve/resolve_proxy.cpp
+++ b/tests/inner/resolve/resolve_proxy.cpp
@@ -153,10 +153,6 @@ busy_thread_func(
 
 // When too many rpclib server handler threads are busy, a following
 // resolve_sync request should immediately fail.
-// The error message should contain "all threads for this request type are
-// busy" but due to what seems to be an rpclib bug this can also be "server
-// could not find function 're". The _length_ of the error message is
-// correct, but the text is wrong.
 TEST_CASE("rpclib server busy on many parallel resolve_sync requests", tag)
 {
     std::string proxy_name{"rpclib"};
@@ -184,7 +180,10 @@ TEST_CASE("rpclib server busy on many parallel resolve_sync requests", tag)
         }
     }
     REQUIRE(progress.error_occurred());
-    // REQUIRE(progress.error_message().find("busy") != std::string::npos);
+    REQUIRE(
+        progress.error_message().find(
+            "all threads for this request type are busy")
+        != std::string::npos);
 
     // Wait until at least one server thread has become idle again.
     std::this_thread::sleep_for(std::chrono::milliseconds(400));

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -30,7 +30,6 @@
         "msgpack",
         "nlohmann-json",
         "openssl",
-        "rpclib",
         "simdjson",
         "spdlog",
         "sqlite3",


### PR DESCRIPTION
resolve_sync requests to the rpclib server fail with "busy" if they would take the last handler thread.