### PR TITLE
Use latest GitHub Actions actions

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -17,7 +17,7 @@ jobs:
         config: [Debug, Release]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -17,7 +17,7 @@ jobs:
         config: [Debug, Release]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -40,13 +40,13 @@ jobs:
         cmake --build build --target preprocessing -j4
 
     - name: Upload preprocessed headers as build artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: preprocessed
         path: build/generated
 
     - name: Deploy preprocessed headers to preprocessor-output repo
-      uses: JamesIves/github-pages-deploy-action@v4.4.1
+      uses: JamesIves/github-pages-deploy-action@v4.5.0
       with:
         repository-name: open-cradle/preprocessor-output
         branch: output
@@ -65,7 +65,7 @@ jobs:
         config: [Debug, Release]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -74,7 +74,7 @@ jobs:
         committish: 7ba0ba7334c3346e7eee1e049ba85da193a8d821
 
     - name: Download preprocessed headers
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: preprocessed
         path: preprocessed

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
GitHub Actions actions using Node 16 are being deprecated.
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.