### PR TITLE
Optional blob file serialization

### DIFF
--- a/src/cradle/inner/encodings/cereal_value.h
+++ b/src/cradle/inner/encodings/cereal_value.h
@@ -24,7 +24,8 @@ save(Archive& archive, Value const& val)
     requires serializable_via_cereal<Value>::value
 {
     // TODO convert to blob file if Value wants that?
-    save(archive, serialize_value(val));
+    bool allow_blob_files{true};
+    save(archive, serialize_value(val, allow_blob_files));
 }
 
 template<typename Archive, typename Value>

--- a/src/cradle/inner/encodings/msgpack_packer.cpp
+++ b/src/cradle/inner/encodings/msgpack_packer.cpp
@@ -1,0 +1,31 @@
+#include <utility>
+
+#include <cradle/inner/core/type_interfaces.h>
+#include <cradle/inner/encodings/msgpack_packer.h>
+
+namespace cradle {
+
+void
+msgpack_ostream::write(char const* data, std::streamsize count)
+{
+    ss_.write(data, count);
+}
+
+blob
+msgpack_ostream::get_blob() &&
+{
+    return make_blob(std::move(ss_).str());
+}
+
+std::string
+msgpack_ostream::str() const
+{
+    return ss_.str();
+}
+
+msgpack_packer::msgpack_packer(msgpack_ostream& os, bool allow_blob_files)
+    : msgpack::packer<msgpack_ostream>(os), allow_blob_files_{allow_blob_files}
+{
+}
+
+} // namespace cradle

--- a/src/cradle/inner/encodings/msgpack_packer.h
+++ b/src/cradle/inner/encodings/msgpack_packer.h
@@ -1,0 +1,50 @@
+#ifndef CRADLE_INNER_ENCODINGS_MSGPACK_PACKER_H
+#define CRADLE_INNER_ENCODINGS_MSGPACK_PACKER_H
+
+#include <sstream>
+#include <string>
+
+#include <msgpack.hpp>
+
+#include <cradle/inner/core/type_definitions.h>
+
+namespace cradle {
+
+// A string stream that class msgpack_packer packs into.
+class msgpack_ostream
+{
+ public:
+    void
+    write(char const* data, std::streamsize count);
+
+    blob
+    get_blob() &&;
+
+    std::string
+    str() const;
+
+ private:
+    std::ostringstream ss_;
+};
+
+// A msgpack packer decorating the original one, and limited to writing to
+// msgpack_ostream only.
+// Note that the base class has no virtual destructor.
+class msgpack_packer : public msgpack::packer<msgpack_ostream>
+{
+ public:
+    msgpack_packer(msgpack_ostream& os, bool allow_blob_files);
+
+    bool
+    allow_blob_files() const
+    {
+        return allow_blob_files_;
+    }
+
+ private:
+    bool allow_blob_files_;
+};
+
+} // namespace cradle
+
+#endif

--- a/src/cradle/inner/encodings/msgpack_value.h
+++ b/src/cradle/inner/encodings/msgpack_value.h
@@ -14,13 +14,14 @@
 #include <cradle/inner/core/type_definitions.h>
 #include <cradle/inner/core/type_interfaces.h>
 #include <cradle/inner/encodings/msgpack_adaptors_main.h>
+#include <cradle/inner/encodings/msgpack_packer.h>
 
 namespace cradle {
 
 // Serializes a value to a msgpack-encoded byte sequence, stored in a blob
 template<typename Value>
 blob
-serialize_value(Value const& value)
+serialize_value(Value const& value, bool allow_blob_files)
 {
     if constexpr (std::same_as<Value, blob>)
     {
@@ -29,9 +30,9 @@ serialize_value(Value const& value)
         // information that msgpack::pack() would normally add.
         return value;
     }
-    std::stringstream ss;
-    msgpack::pack(ss, value);
-    return make_blob(std::move(ss).str());
+    msgpack_ostream os;
+    msgpack_packer(os, allow_blob_files).pack(value);
+    return std::move(os).get_blob();
 }
 
 // Deserializes a value from a msgpack-encoded byte sequence

--- a/src/cradle/inner/resolve/seri_resolver.h
+++ b/src/cradle/inner/resolve/seri_resolver.h
@@ -62,10 +62,13 @@ class seri_resolver_impl : public seri_resolver_intf
         auto req{deserialize_request<Req>(
             ctx.get_resources(), std::move(seri_req))};
         ResolutionConstraintsLocal constraints;
+        // TODO resolve_request also serializes value if fully caching;
+        // allowing blob files or not depending on the cache.
         auto value = co_await resolve_request(
             ctx, req, seri_lock.lock_ptr, constraints);
+        bool allow_blob_files{true};
         co_return serialized_result{
-            serialize_value(value), seri_lock.record_id};
+            serialize_value(value, allow_blob_files), seri_lock.record_id};
     }
 };
 

--- a/src/cradle/inner/service/secondary_storage_intf.h
+++ b/src/cradle/inner/service/secondary_storage_intf.h
@@ -23,18 +23,30 @@ class secondary_storage_intf
     clear()
         = 0;
 
-    // Reads the value for key.
-    // Returns std::nullopt if the value is not in the storage.
-    // Throws on other errors.
+    // Reads the serialized value for key.
+    // Returns std::nullopt if the value is not in the storage;
+    // throws on other errors.
     // This could be a coroutine so takes arguments by value.
     virtual cppcoro::task<std::optional<blob>>
     read(std::string key) = 0;
 
+    // Writes a serialized value under the given key.
     // This operation may be synchronous or asynchronous.
     // If synchronous, it will throw on errors.
     // This could be a coroutine so takes arguments by value.
     virtual cppcoro::task<void>
     write(std::string key, blob value) = 0;
+
+    // Returns true if this storage medium allows a serialized value to
+    // contain references to blob files.
+    // If this returns false, a write() caller should ensure that any blob
+    // files _inside_ the to-be-written value have been expanded. The value
+    // itself can still be a blob file, and if so the write() implementation
+    // should interpret it as a byte sequence, disregarding the blob file
+    // aspect.
+    virtual bool
+    allow_blob_files() const
+        = 0;
 };
 
 } // namespace cradle

--- a/src/cradle/plugins/requests_storage/http/http_requests_storage.h
+++ b/src/cradle/plugins/requests_storage/http/http_requests_storage.h
@@ -38,6 +38,12 @@ class http_requests_storage : public secondary_storage_intf
     cppcoro::task<void>
     write(std::string key, blob value) override;
 
+    bool
+    allow_blob_files() const override
+    {
+        return false;
+    }
+
  private:
     inner_resources& resources_;
     int port_;

--- a/src/cradle/plugins/secondary_cache/http/http_cache.h
+++ b/src/cradle/plugins/secondary_cache/http/http_cache.h
@@ -47,6 +47,12 @@ class http_cache : public secondary_storage_intf
     cppcoro::task<void>
     write(std::string key, blob value) override;
 
+    bool
+    allow_blob_files() const override
+    {
+        return false;
+    }
+
  private:
     std::unique_ptr<http_cache_impl> impl_;
 };

--- a/src/cradle/plugins/secondary_cache/local/local_disk_cache.h
+++ b/src/cradle/plugins/secondary_cache/local/local_disk_cache.h
@@ -87,6 +87,12 @@ class local_disk_cache : public secondary_storage_intf
     cppcoro::task<void>
     write(std::string key, blob value) override;
 
+    bool
+    allow_blob_files() const override
+    {
+        return true;
+    }
+
     // Get summary information about the cache.
     disk_cache_info
     get_summary_info();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,7 +17,9 @@ set_source_files_properties(
 # Define a library containing basic test support.
 add_library(basic_test_support
     support/common.cpp
-    support/inner_service.cpp)
+    support/inner_service.cpp
+    support/make_test_blob.cpp
+    support/simple_storage.cpp)
 add_dependencies(basic_test_support
     deploy_dir_file_target)
 target_link_libraries(basic_test_support PUBLIC

--- a/tests/inner/encodings/msgpack_adaptors_main.cpp
+++ b/tests/inner/encodings/msgpack_adaptors_main.cpp
@@ -1,5 +1,4 @@
 #include <memory>
-#include <sstream>
 #include <string>
 
 #include <catch2/catch.hpp>
@@ -9,6 +8,7 @@
 #include <cradle/inner/core/type_definitions.h>
 #include <cradle/inner/core/type_interfaces.h>
 #include <cradle/inner/encodings/msgpack_adaptors_main.h>
+#include <cradle/inner/encodings/msgpack_packer.h>
 #include <cradle/inner/service/resources.h>
 
 using namespace cradle;
@@ -27,16 +27,17 @@ make_string(std::vector<size_t> const& v)
 static void
 test_one(blob const& x, std::string const& expected, bool with_zone)
 {
-    std::stringstream ss;
+    bool const allow_blob_files{true};
+    msgpack_ostream ss;
     if (with_zone)
     {
         auto z = std::make_unique<msgpack::zone>();
         msgpack::object x_obj{x, *z};
-        msgpack::pack(ss, x_obj);
+        msgpack_packer(ss, allow_blob_files).pack(x_obj);
     }
     else
     {
-        msgpack::pack(ss, x);
+        msgpack_packer(ss, allow_blob_files).pack(x);
     }
     auto serialized = ss.str();
     REQUIRE(serialized == expected);
@@ -105,7 +106,7 @@ TEST_CASE("msgpack converting file blob (main)", "[encodings][msgpack]")
 TEST_CASE("msgpack decoding throws on bad data (main)", "[encodings][msgpack]")
 {
     int x{};
-    std::stringstream ss;
+    msgpack_ostream ss;
     msgpack::pack(ss, x);
     auto serialized = ss.str();
 
@@ -119,7 +120,7 @@ TEST_CASE("msgpack decoding throws on bad data (main)", "[encodings][msgpack]")
 static void
 test_one_throws(blob const& x, bool with_zone)
 {
-    std::stringstream ss;
+    msgpack_ostream ss;
     if (with_zone)
     {
         auto z = std::make_unique<msgpack::zone>();

--- a/tests/inner/resolve/demo_class.cpp
+++ b/tests/inner/resolve/demo_class.cpp
@@ -6,6 +6,7 @@
 
 #include "../../support/common.h"
 #include "../../support/inner_service.h"
+#include "../../support/make_test_blob.h"
 #include <cradle/inner/resolve/resolve_request.h>
 #include <cradle/inner/service/resources.h>
 #include <cradle/plugins/domain/testing/context.h>
@@ -17,20 +18,6 @@ using namespace cradle;
 namespace {
 
 static char const tag[] = "[demo_class]";
-
-blob
-make_test_blob(
-    local_context_intf& ctx,
-    std::string const& contents,
-    bool use_shared_memory)
-{
-    auto size = contents.size();
-    auto owner = ctx.make_data_owner(size, use_shared_memory);
-    auto* data = reinterpret_cast<char*>(owner->data());
-    std::copy_n(contents.data(), size, data);
-    ctx.on_value_complete();
-    return blob{std::move(owner), as_bytes(data), size};
-}
 
 // Tests resolving the two requests related to demo_class
 template<caching_level_type caching_level>

--- a/tests/support/make_test_blob.cpp
+++ b/tests/support/make_test_blob.cpp
@@ -1,0 +1,24 @@
+#include <algorithm>
+#include <utility>
+
+#include "make_test_blob.h"
+#include <cradle/inner/core/type_interfaces.h>
+#include <cradle/inner/requests/generic.h>
+
+namespace cradle {
+
+blob
+make_test_blob(
+    local_context_intf& ctx,
+    std::string const& contents,
+    bool use_shared_memory)
+{
+    auto size = contents.size();
+    auto owner = ctx.make_data_owner(size, use_shared_memory);
+    auto* data = reinterpret_cast<char*>(owner->data());
+    std::copy_n(contents.data(), size, data);
+    ctx.on_value_complete();
+    return blob{std::move(owner), as_bytes(data), size};
+}
+
+} // namespace cradle

--- a/tests/support/make_test_blob.h
+++ b/tests/support/make_test_blob.h
@@ -1,0 +1,20 @@
+#ifndef CRADLE_TESTS_SUPPORT_MAKE_TEST_BLOB_H
+#define CRADLE_TESTS_SUPPORT_MAKE_TEST_BLOB_H
+
+#include <string>
+
+#include <cradle/inner/core/type_definitions.h>
+
+namespace cradle {
+
+class local_context_intf;
+
+blob
+make_test_blob(
+    local_context_intf& ctx,
+    std::string const& contents,
+    bool use_shared_memory);
+
+} // namespace cradle
+
+#endif

--- a/tests/support/simple_storage.cpp
+++ b/tests/support/simple_storage.cpp
@@ -1,0 +1,49 @@
+#include "simple_storage.h"
+#include <cradle/inner/core/exception.h>
+#include <cradle/inner/core/type_interfaces.h>
+
+namespace cradle {
+
+void
+simple_blob_storage::clear()
+{
+    throw not_implemented_error();
+}
+
+cppcoro::task<std::optional<blob>>
+simple_blob_storage::read(std::string key)
+{
+    auto it = storage_.find(key);
+    co_return it != storage_.end() ? std::make_optional(it->second)
+                                   : std::nullopt;
+}
+
+cppcoro::task<void>
+simple_blob_storage::write(std::string key, blob value)
+{
+    storage_[key] = value;
+    co_return;
+}
+
+void
+simple_string_storage::clear()
+{
+    throw not_implemented_error();
+}
+
+cppcoro::task<std::optional<blob>>
+simple_string_storage::read(std::string key)
+{
+    auto it = storage_.find(key);
+    co_return it != storage_.end() ? std::make_optional(make_blob(it->second))
+                                   : std::nullopt;
+}
+
+cppcoro::task<void>
+simple_string_storage::write(std::string key, blob value)
+{
+    storage_[key] = to_string(value);
+    co_return;
+}
+
+} // namespace cradle

--- a/tests/support/simple_storage.h
+++ b/tests/support/simple_storage.h
@@ -1,0 +1,77 @@
+#ifndef CRADLE_TESTS_SUPPORT_SIMPLE_STORAGE_H
+#define CRADLE_TESTS_SUPPORT_SIMPLE_STORAGE_H
+
+#include <map>
+#include <optional>
+#include <string>
+
+#include <cppcoro/task.hpp>
+
+#include <cradle/inner/core/type_definitions.h>
+#include <cradle/inner/service/secondary_storage_intf.h>
+
+namespace cradle {
+
+// Simple secondary storage allowing blob files, and storing outer blobs as
+// they are; similar to a disk cache.
+class simple_blob_storage : public secondary_storage_intf
+{
+ public:
+    void
+    clear() override;
+
+    cppcoro::task<std::optional<blob>>
+    read(std::string key) override;
+
+    cppcoro::task<void>
+    write(std::string key, blob value) override;
+
+    bool
+    allow_blob_files() const override
+    {
+        return true;
+    }
+
+    int
+    size() const
+    {
+        return static_cast<int>(storage_.size());
+    }
+
+ private:
+    std::map<std::string, blob> storage_;
+};
+
+// Simple secondary storage disallowing blob files, and storing outer blobs as
+// byte sequences; similar to an HTTP cache.
+class simple_string_storage : public secondary_storage_intf
+{
+ public:
+    void
+    clear() override;
+
+    cppcoro::task<std::optional<blob>>
+    read(std::string key) override;
+
+    cppcoro::task<void>
+    write(std::string key, blob value) override;
+
+    bool
+    allow_blob_files() const override
+    {
+        return false;
+    }
+
+    int
+    size() const
+    {
+        return static_cast<int>(storage_.size());
+    }
+
+ private:
+    std::map<std::string, std::string> storage_;
+};
+
+} // namespace cradle
+
+#endif


### PR DESCRIPTION
Each secondary_storage_intf implementation decides whether it wants a file blob to be stored as a reference to the file, or as inline data. E.g. the local disk cache wants the reference, but an HTTP cache wants inline data.
The "allow blob files" flag is passed on to a msgpack_packer object wrapping the original msgpack packer. All occurrences of the original packer (i.e., msgpack::pack() calls) have been replaced by msgpack_packer.